### PR TITLE
feat(dsl): dsl extension for postgrest specific operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 
 </div>
 
-**QueryDSL-PostgRest** is a [PostgRest](https://github.com/postgrest/postgrest) implementation of [QueryDSL](https://github.com/Ouest-France/querydsl) library 
+**QueryDSL-PostgRest** is a [PostgRest](https://github.com/postgrest/postgrest) implementation
+of [QueryDSL](https://github.com/Ouest-France/querydsl) library
 and provides class and annotation to improve your developer experience using PostgRest.
 
 **PostgREST** is an open source project that provides a fully RESTful API from any existing PostgreSQL database
@@ -44,7 +45,8 @@ implementation 'fr.ouestfrance.querydsl:querydsl-postgrest:${querydsl-postgrest.
 QueryDsl postgrest provides class to simplify querying postgrest api using PostgrestClient,
 It actually provides by default WebClient adapter `PostgrestWebClient` adapter.
 
-It's really easy to create your own HttpClientAdapter (RestTemplate, OkHttpClient, HttpConnexion, ...) by implementing `PostgrestClient` interface.
+It's really easy to create your own HttpClientAdapter (RestTemplate, OkHttpClient, HttpConnexion, ...) by
+implementing `PostgrestClient` interface.
 
 You can also specify authenticators, interceptors (retry, transform) and every configuration (timeout, default headers,
 cookies, ...) you need to deploy.
@@ -75,7 +77,6 @@ public class PostgrestConfiguration {
 }
 ```
 
-
 ### Create your first repository
 
 #### Specify your first search criteria
@@ -95,19 +96,20 @@ import lombok.Setter;
 public class UserSearch {
     @FilterField
     String id;
-    @FilterField(operation = FilterOperation.LIKE)
+    @FilterField(operation = FilterOperation.LIKE.class)
     String name;
 }
 ```
 
 *@Since 1.1.0 - Record Support*
+
 ```java
 public record UserSearch(
         @FilterField String id,
-        @FilterField(operation = FilterOperation.LIKE) String name
-){}
+        @FilterField(operation = FilterOperation.LIKE.class) String name
+) {
+}
 ```
-
 
 #### Create your repository
 
@@ -115,7 +117,7 @@ To access data, you have to create Repository for your type and put `@PostgrestC
 
 | Property      | Required | Format | Description                                                 | Example         |
 |---------------|----------|--------|-------------------------------------------------------------|-----------------|
-| resource      | O        | String | Resource name in the postgrest api                         | "users"         |
+| resource      | O        | String | Resource name in the postgrest api                          | "users"         |
 | countStrategy | X        | String | Count strategy (exact, planned, estimated) default is exact | CountType.EXACT |
 
 ```java
@@ -191,14 +193,14 @@ public class UserService {
 
 ### Advanced features
 
-
 #### Vertical filtering
 
 When certain columns are wide (such as those holding binary data), it is more efficient for the server to withhold them
 in a response. The client can specify which columns are required using the select parameter.
 This can be defined by annotation `@Select`
 
-Select annotation can be added on the Repository but also to the criteria object that allow you to add specific selection for filtering
+Select annotation can be added on the Repository but also to the criteria object that allow you to add specific
+selection for filtering
 
 | Property | Required | Format | Description              | Example     |
 |----------|----------|--------|--------------------------|-------------|
@@ -209,13 +211,16 @@ You can add extra selection by adding `@Select` annotation.
 In this example there is an inner join on `Posts.author` and selecting only `firstName` and `lastName`
 
 ```java
+
 @PostgrestConfiguration(resource = "posts")
-@Select(alias="author", value="author!inner(firstName, lastName)")
+@Select(alias = "author", value = "author!inner(firstName, lastName)")
 public class PostRepository extends PostgrestRepository<Post> {
-    
+
 }
 ```
+
 Will return json like this :
+
 ```json
 [
   {
@@ -239,7 +244,9 @@ Will return json like this :
 
 #### Headers
 
-This library allow strategy based on `Prefer` header see official [PostgREST Documentation](https://postgrest.org/en/stable/references/api/preferences.html) by adding `@Header` annotation over your Repositoru
+This library allow strategy based on `Prefer` header see
+official [PostgREST Documentation](https://postgrest.org/en/stable/references/api/preferences.html) by adding `@Header`
+annotation over your Repositoru
 
 ```java
 // Return representation object for all functions
@@ -252,7 +259,8 @@ public class PostRepository extends PostgrestRepository<Post> {
 
 #### Logical condition
 
-Any chance you want to have a more complex condition, it's possible to make mixin or / and condition by using `groupName`
+Any chance you want to have a more complex condition, it's possible to make mixin or / and condition by
+using `groupName`
 
 ```java
 
@@ -264,13 +272,14 @@ public class PostRequestWithSize {
     // size = $size OR (filterFormats.minSize < size AND filterFormats.maxSize > size)
     @FilterField(key = "size", groupName = "sizeOrGroup")
     @FilterFields(groupName = "sizeOrGroup", value = {
-            @FilterField(key = "filterFormats.minSize", operation = FilterOperation.GTE),
-            @FilterField(key = "filterFormats.maxSize", operation = FilterOperation.LTE, orNull = true)
+            @FilterField(key = "filterFormats.minSize", operation = FilterOperation.GTE.class),
+            @FilterField(key = "filterFormats.maxSize", operation = FilterOperation.LTE.class, orNull = true)
     })
     private String size;
 }
 ```
-or on multiple fields 
+
+or on multiple fields
 
 ```java
 public class PostRequestWithAuthorOrSubject {
@@ -286,6 +295,15 @@ public class PostRequestWithAuthorOrSubject {
 
 ```
 
+#### PostgrestFilterOperation
+
+extends FilterOperation with
+
+| Operator | Description                       |
+|----------|-----------------------------------|
+| ILIKE    | Case-insensitive LIKE             |  
+| CS       | Contains for JSON/Range datatype  |
+| CD       | Contained for JSON/Range datatype |
 
 ## Need Help ?
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>fr.ouestfrance.querydsl</groupId>
     <artifactId>querydsl-postgrest</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>querydsl-postgrest</name>
-    <description>Implementation of unified queryDSL for postgRest API </description>
+    <description>Implementation of unified queryDSL for postgRest API</description>
     <url>https://github.com/ouest-france/querydsl-postgrest</url>
 
     <licenses>
@@ -53,7 +54,7 @@
         <dependency>
             <groupId>fr.ouestfrance.querydsl</groupId>
             <artifactId>querydsl</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>fr.ouestfrance.querydsl</groupId>
             <artifactId>querydsl</artifactId>
-            <version>1.2.0-SNAPSHOT</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestFilterOperation.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestFilterOperation.java
@@ -1,0 +1,28 @@
+package fr.ouestfrance.querydsl.postgrest;
+
+import fr.ouestfrance.querydsl.FilterOperation;
+import fr.ouestfrance.querydsl.service.validators.ValidatedBy;
+import fr.ouestfrance.querydsl.service.validators.impl.StringValidator;
+
+public interface PostgrestFilterOperation {
+    /**
+     * Case-insensitive like
+     */
+    @ValidatedBy(StringValidator.class)
+    class ILIKE implements FilterOperation {
+    }
+
+    /**
+     * Contains for JSON/Range datatype
+     */
+    @ValidatedBy(StringValidator.class)
+    class CS implements FilterOperation {
+    }
+
+    /**
+     * Contained for JSON/Range datatype
+     */
+    @ValidatedBy(StringValidator.class)
+    class CD implements FilterOperation {
+    }
+}

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/criterias/ByIds.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/criterias/ByIds.java
@@ -1,12 +1,11 @@
 package fr.ouestfrance.querydsl.postgrest.criterias;
 
+import java.util.List;
+
 import fr.ouestfrance.querydsl.FilterField;
 import fr.ouestfrance.querydsl.FilterOperation;
 
-import java.io.Serializable;
-import java.util.List;
-
-record ByIds(@FilterField(operation = FilterOperation.IN)
+record ByIds(@FilterField(operation = FilterOperation.IN.class)
              List<Comparable<?>> id) {
 
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/CaseInsensitiveLikeMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/CaseInsensitiveLikeMapper.java
@@ -1,23 +1,24 @@
 package fr.ouestfrance.querydsl.postgrest.mappers;
 
 import fr.ouestfrance.querydsl.FilterOperation;
+import fr.ouestfrance.querydsl.postgrest.PostgrestFilterOperation;
 import fr.ouestfrance.querydsl.postgrest.model.Filter;
 import fr.ouestfrance.querydsl.postgrest.model.impl.QueryFilter;
 
 
 /**
- * Concrete mapping for notEquals
+ * Concrete mapping for like
  */
-public class NotEqualsMapper extends AbstractMapper {
+public class CaseInsensitiveLikeMapper extends AbstractMapper {
 
     @Override
     public Filter getFilter(String field, Object value) {
-        return QueryFilter.of(field, Operators.NOT_EQUALS, value);
+        return QueryFilter.of(field, Operators.ILIKE, value);
     }
 
 
     @Override
     public Class<? extends FilterOperation> operation() {
-        return FilterOperation.NEQ.class;
+        return PostgrestFilterOperation.ILIKE.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/ContainedMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/ContainedMapper.java
@@ -1,23 +1,23 @@
 package fr.ouestfrance.querydsl.postgrest.mappers;
 
 import fr.ouestfrance.querydsl.FilterOperation;
+import fr.ouestfrance.querydsl.postgrest.PostgrestFilterOperation;
 import fr.ouestfrance.querydsl.postgrest.model.Filter;
 import fr.ouestfrance.querydsl.postgrest.model.impl.QueryFilter;
 
 
 /**
- * Concrete mapping for notEquals
+ * Concrete mapping for equals
  */
-public class NotEqualsMapper extends AbstractMapper {
+public class ContainedMapper extends AbstractMapper {
 
     @Override
     public Filter getFilter(String field, Object value) {
-        return QueryFilter.of(field, Operators.NOT_EQUALS, value);
+        return QueryFilter.of(field, Operators.CONTAINED, value);
     }
-
 
     @Override
     public Class<? extends FilterOperation> operation() {
-        return FilterOperation.NEQ.class;
+        return PostgrestFilterOperation.CD.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/ContainsMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/ContainsMapper.java
@@ -1,23 +1,23 @@
 package fr.ouestfrance.querydsl.postgrest.mappers;
 
 import fr.ouestfrance.querydsl.FilterOperation;
+import fr.ouestfrance.querydsl.postgrest.PostgrestFilterOperation;
 import fr.ouestfrance.querydsl.postgrest.model.Filter;
 import fr.ouestfrance.querydsl.postgrest.model.impl.QueryFilter;
 
 
 /**
- * Concrete mapping for notEquals
+ * Concrete mapping for equals
  */
-public class NotEqualsMapper extends AbstractMapper {
+public class ContainsMapper extends AbstractMapper {
 
     @Override
     public Filter getFilter(String field, Object value) {
-        return QueryFilter.of(field, Operators.NOT_EQUALS, value);
+        return QueryFilter.of(field, Operators.CONTAINS, value);
     }
-
 
     @Override
     public Class<? extends FilterOperation> operation() {
-        return FilterOperation.NEQ.class;
+        return PostgrestFilterOperation.CS.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/EqualsMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/EqualsMapper.java
@@ -14,8 +14,9 @@ public class EqualsMapper extends AbstractMapper {
     public Filter getFilter(String field, Object value) {
         return QueryFilter.of(field, Operators.EQUALS_TO, value);
     }
+
     @Override
-    public FilterOperation operation() {
-        return FilterOperation.EQ;
+    public Class<? extends FilterOperation> operation() {
+        return FilterOperation.EQ.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/GreaterThanEqualsMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/GreaterThanEqualsMapper.java
@@ -1,8 +1,8 @@
 package fr.ouestfrance.querydsl.postgrest.mappers;
 
+import fr.ouestfrance.querydsl.FilterOperation;
 import fr.ouestfrance.querydsl.postgrest.model.Filter;
 import fr.ouestfrance.querydsl.postgrest.model.impl.QueryFilter;
-import fr.ouestfrance.querydsl.FilterOperation;
 
 
 /**
@@ -15,9 +15,8 @@ public class GreaterThanEqualsMapper extends AbstractMapper {
         return QueryFilter.of(field, Operators.GREATER_THAN_EQUALS, value);
     }
 
-
     @Override
-    public FilterOperation operation() {
-        return FilterOperation.GTE;
+    public Class<? extends FilterOperation> operation() {
+        return FilterOperation.GTE.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/GreaterThanMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/GreaterThanMapper.java
@@ -16,7 +16,7 @@ public class GreaterThanMapper extends AbstractMapper {
 
 
     @Override
-    public FilterOperation operation() {
-        return FilterOperation.GT;
+    public Class<? extends FilterOperation> operation() {
+        return FilterOperation.GT.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/InMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/InMapper.java
@@ -1,12 +1,12 @@
 package fr.ouestfrance.querydsl.postgrest.mappers;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import fr.ouestfrance.querydsl.FilterOperation;
 import fr.ouestfrance.querydsl.postgrest.model.Filter;
 import fr.ouestfrance.querydsl.postgrest.model.exceptions.PostgrestRequestException;
 import fr.ouestfrance.querydsl.postgrest.model.impl.QueryFilter;
-
-import java.util.Collection;
-import java.util.stream.Collectors;
 
 
 /**
@@ -24,7 +24,7 @@ public class InMapper extends AbstractMapper {
 
 
     @Override
-    public FilterOperation operation() {
-        return FilterOperation.IN;
+    public Class<? extends FilterOperation> operation() {
+        return FilterOperation.IN.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/LessThanEqualsMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/LessThanEqualsMapper.java
@@ -16,7 +16,7 @@ public class LessThanEqualsMapper extends AbstractMapper {
 
 
     @Override
-    public FilterOperation operation() {
-        return FilterOperation.LTE;
+    public Class<? extends FilterOperation> operation() {
+        return FilterOperation.LTE.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/LessThanMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/LessThanMapper.java
@@ -18,7 +18,7 @@ public class LessThanMapper extends AbstractMapper {
 
 
     @Override
-    public FilterOperation operation() {
-        return FilterOperation.LT;
+    public Class<? extends FilterOperation> operation() {
+        return FilterOperation.LT.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/LikeMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/LikeMapper.java
@@ -17,7 +17,7 @@ public class LikeMapper extends AbstractMapper {
 
 
     @Override
-    public FilterOperation operation() {
-        return FilterOperation.LIKE;
+    public Class<? extends FilterOperation> operation() {
+        return FilterOperation.LIKE.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/NotInMapper.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/NotInMapper.java
@@ -1,12 +1,12 @@
 package fr.ouestfrance.querydsl.postgrest.mappers;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import fr.ouestfrance.querydsl.FilterOperation;
 import fr.ouestfrance.querydsl.postgrest.model.Filter;
 import fr.ouestfrance.querydsl.postgrest.model.exceptions.PostgrestRequestException;
 import fr.ouestfrance.querydsl.postgrest.model.impl.QueryFilter;
-
-import java.util.Collection;
-import java.util.stream.Collectors;
 
 
 /**
@@ -23,7 +23,7 @@ public class NotInMapper extends AbstractMapper {
     }
 
     @Override
-    public FilterOperation operation() {
-        return FilterOperation.NOT_IN;
+    public Class<? extends FilterOperation> operation() {
+        return FilterOperation.NOTIN.class;
     }
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/Operators.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/mappers/Operators.java
@@ -37,6 +37,10 @@ public final class Operators {
      */
     public static final String LIKE = "like";
     /**
+     * Case-insensitive Like operation
+     */
+    public static final String ILIKE = "ilike";
+    /**
      * Not equals operation
      */
     public static final String NOT_EQUALS = "neq";
@@ -52,4 +56,12 @@ public final class Operators {
      * is operation
      */
     public static final String IS = "is";
+    /**
+     * Contains operation for JSON/Range datatype
+     */
+    public static final String CONTAINS = "cs";
+    /**
+     * Contained operation for JSON/Range datatype
+     */
+    public static final String CONTAINED = "cd";
 }

--- a/src/main/java/fr/ouestfrance/querydsl/postgrest/services/ext/PostgrestQueryProcessorService.java
+++ b/src/main/java/fr/ouestfrance/querydsl/postgrest/services/ext/PostgrestQueryProcessorService.java
@@ -1,5 +1,7 @@
 package fr.ouestfrance.querydsl.postgrest.services.ext;
 
+import java.util.List;
+
 import fr.ouestfrance.querydsl.FilterOperation;
 import fr.ouestfrance.querydsl.model.GroupFilter;
 import fr.ouestfrance.querydsl.postgrest.mappers.*;
@@ -7,8 +9,6 @@ import fr.ouestfrance.querydsl.postgrest.model.Filter;
 import fr.ouestfrance.querydsl.postgrest.model.impl.CompositeFilter;
 import fr.ouestfrance.querydsl.service.ext.Mapper;
 import fr.ouestfrance.querydsl.service.ext.QueryDslProcessorService;
-
-import java.util.List;
 
 /**
  * Concrete implementation of QueryDslProcessorService
@@ -21,10 +21,11 @@ public class PostgrestQueryProcessorService implements QueryDslProcessorService<
     private static final List<Mapper<Filter>> MAPPERS = List.of(new EqualsMapper(),
             new GreaterThanEqualsMapper(), new GreaterThanMapper(),
             new InMapper(), new LessThanEqualsMapper(), new LessThanMapper(),
-            new LikeMapper(), new NotEqualsMapper(), new NotInMapper());
+            new LikeMapper(), new NotEqualsMapper(), new NotInMapper(),
+            new CaseInsensitiveLikeMapper(), new ContainsMapper(), new ContainedMapper());
 
     @Override
-    public Mapper<Filter> getMapper(FilterOperation operation) {
+    public Mapper<Filter> getMapper(Class<? extends FilterOperation> operation) {
         return MAPPERS.stream()
                 .filter(x -> x.operation().equals(operation))
                 .findFirst().orElseThrow();

--- a/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostDeleteRequest.java
+++ b/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostDeleteRequest.java
@@ -1,5 +1,7 @@
 package fr.ouestfrance.querydsl.postgrest.app;
 
+import java.util.List;
+
 import fr.ouestfrance.querydsl.FilterField;
 import fr.ouestfrance.querydsl.FilterOperation;
 import lombok.AllArgsConstructor;
@@ -7,16 +9,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDate;
-import java.util.List;
-
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostDeleteRequest {
 
-    @FilterField(operation = FilterOperation.IN)
+    @FilterField(operation = FilterOperation.IN.class)
     private List<String> id;
 
 }

--- a/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostRequest.java
+++ b/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostRequest.java
@@ -1,14 +1,14 @@
 package fr.ouestfrance.querydsl.postgrest.app;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import fr.ouestfrance.querydsl.FilterField;
 import fr.ouestfrance.querydsl.FilterOperation;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @Setter
@@ -18,18 +18,18 @@ public class PostRequest {
 
     @FilterField
     private Integer userId;
-    @FilterField(operation = FilterOperation.NEQ)
+    @FilterField(operation = FilterOperation.NEQ.class)
     private Integer id;
-    @FilterField(operation = FilterOperation.LIKE)
+    @FilterField(operation = FilterOperation.LIKE.class)
     private String title;
-    @FilterField(operation = FilterOperation.GT, key = "birthDate")
-    @FilterField(operation = FilterOperation.LTE, key = "startDate")
-    @FilterField(operation = FilterOperation.GTE, key = "endDate", orNull = true)
-    @FilterField(operation = FilterOperation.LT, key = "deathDate", orNull = true)
+    @FilterField(operation = FilterOperation.GT.class, key = "birthDate")
+    @FilterField(operation = FilterOperation.LTE.class, key = "startDate")
+    @FilterField(operation = FilterOperation.GTE.class, key = "endDate", orNull = true)
+    @FilterField(operation = FilterOperation.LT.class, key = "deathDate", orNull = true)
     private LocalDate validDate;
 
-    @FilterField(operation = FilterOperation.IN, key = "status")
+    @FilterField(operation = FilterOperation.IN.class, key = "status")
     private List<String> codes;
-    @FilterField(operation = FilterOperation.NOT_IN, key = "status")
+    @FilterField(operation = FilterOperation.NOTIN.class, key = "status")
     private List<String> excludes;
 }

--- a/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostRequestWithSize.java
+++ b/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostRequestWithSize.java
@@ -15,8 +15,8 @@ public class PostRequestWithSize {
     // size = $size OR (minSize < size AND maxSize > size)
     @FilterField(key = "size", groupName = "sizeOrGroup")
     @FilterFields(groupName = "sizeOrGroup", value = {
-            @FilterField(key = "filterFormats.minSize", operation = FilterOperation.GTE),
-            @FilterField(key = "filterFormats.maxSize", operation = FilterOperation.LTE, orNull = true)
+            @FilterField(key = "filterFormats.minSize", operation = FilterOperation.GTE.class),
+            @FilterField(key = "filterFormats.maxSize", operation = FilterOperation.LTE.class, orNull = true)
     })
     private String size;
 }

--- a/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PublicationRequest.java
+++ b/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PublicationRequest.java
@@ -1,5 +1,7 @@
 package fr.ouestfrance.querydsl.postgrest.app;
 
+import java.time.LocalDate;
+
 import fr.ouestfrance.querydsl.FilterField;
 import fr.ouestfrance.querydsl.FilterOperation;
 import fr.ouestfrance.querydsl.postgrest.annotations.Select;
@@ -7,8 +9,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -22,10 +22,10 @@ public class PublicationRequest {
     @FilterField(key = "filtrePublication.code")
     String code;
 
-    @FilterField(key = "filtrePublication.dateDebutValidite", operation = FilterOperation.LTE)
-    @FilterField(key = "filtrePublication.dateFinValidite", operation = FilterOperation.GTE, orNull = true)
-    @FilterField(key = "filtreEditionRegroupements.dateDebutValidite", operation = FilterOperation.LTE)
-    @FilterField(key = "filtreEditionRegroupements.dateFinValidite", operation = FilterOperation.GTE, orNull = true)
+    @FilterField(key = "filtrePublication.dateDebutValidite", operation = FilterOperation.LTE.class)
+    @FilterField(key = "filtrePublication.dateFinValidite", operation = FilterOperation.GTE.class, orNull = true)
+    @FilterField(key = "filtreEditionRegroupements.dateDebutValidite", operation = FilterOperation.LTE.class)
+    @FilterField(key = "filtreEditionRegroupements.dateFinValidite", operation = FilterOperation.GTE.class, orNull = true)
     LocalDate dateValide;
 
     @FilterField(key = "filtreDepartement.edition_v1.departement_v1.code")

--- a/src/test/java/fr/ouestfrance/querydsl/postgrest/mappers/InMapperTest.java
+++ b/src/test/java/fr/ouestfrance/querydsl/postgrest/mappers/InMapperTest.java
@@ -1,18 +1,18 @@
 package fr.ouestfrance.querydsl.postgrest.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import fr.ouestfrance.querydsl.FilterOperation;
 import fr.ouestfrance.querydsl.model.SimpleFilter;
 import fr.ouestfrance.querydsl.postgrest.model.exceptions.PostgrestRequestException;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InMapperTest {
 
     @Test
     void shouldRaiseExceptionIfNotCollection() {
         InMapper inMapper = new InMapper();
-        SimpleFilter filter = new SimpleFilter("filter", FilterOperation.IN, false, null);
+        SimpleFilter filter = new SimpleFilter("filter", FilterOperation.IN.class, false, null);
         assertThrows(PostgrestRequestException.class, () -> inMapper.map(filter, "value"));
     }
 }

--- a/src/test/java/fr/ouestfrance/querydsl/postgrest/mappers/NotInMapperTest.java
+++ b/src/test/java/fr/ouestfrance/querydsl/postgrest/mappers/NotInMapperTest.java
@@ -1,18 +1,18 @@
 package fr.ouestfrance.querydsl.postgrest.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import fr.ouestfrance.querydsl.FilterOperation;
 import fr.ouestfrance.querydsl.model.SimpleFilter;
 import fr.ouestfrance.querydsl.postgrest.model.exceptions.PostgrestRequestException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 class NotInMapperTest {
 
     @Test
-    void shouldRaiseExceptionIfNotCollection(){
+    void shouldRaiseExceptionIfNotCollection() {
         NotInMapper notInMapper = new NotInMapper();
-        SimpleFilter filter = new SimpleFilter("code", FilterOperation.IN, false, null);
-        assertThrows(PostgrestRequestException.class, ()->notInMapper.map(filter, "value"));
+        SimpleFilter filter = new SimpleFilter("code", FilterOperation.IN.class, false, null);
+        assertThrows(PostgrestRequestException.class, () -> notInMapper.map(filter, "value"));
     }
 }


### PR DESCRIPTION
Allow to handle new querydsl version which offer dsl extension.

FilterField in query-dsl is used on simple logical operator (eq, not_equals, in, not_in, greater_than), but postgrest get some specific domain language (like contains / contained / fulltext / ...) 

