### PR TITLE
fix(pagenumber): fix pagenumber result error

### DIFF
--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestClient.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestClient.java
@@ -1,6 +1,6 @@
 package fr.ouestfrance.querydsl.postgrest;
 
-import fr.ouestfrance.querydsl.postgrest.model.Page;
+import fr.ouestfrance.querydsl.postgrest.model.RangeResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -20,8 +20,8 @@ public interface PostgrestClient {
      * @return ResponseEntity containing the results
      */
 
-    <T> Page<T> search(String resource, Map<String, List<String>> params,
-                       Map<String, List<String>> headers, Class<T> clazz);
+    <T> RangeResponse<T> search(String resource, Map<String, List<String>> params,
+                                Map<String, List<String>> headers, Class<T> clazz);
 
     /**
      * Save body

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/Page.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/Page.java
@@ -3,7 +3,6 @@ package fr.ouestfrance.querydsl.postgrest.model;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -101,11 +100,10 @@ public interface Page<T> extends Iterable<T> {
 
     /**
      * Check that page has next page
+     *
      * @return true if totalPages is greater than pageNumber
      */
     default boolean hasNext() {
-        return Optional.ofNullable(getPageable())
-                .map(pageable -> pageable.getPageNumber() +1 < getTotalPages())
-                .orElse(false);
+        return getPageable().getPageNumber() + 1 < getTotalPages();
     }
 }

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/PageImpl.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/PageImpl.java
@@ -21,7 +21,6 @@ public class PageImpl<T> implements Page<T> {
     /**
      * Request information
      */
-    @Setter
     private Pageable pageable;
     /**
      * Total elements
@@ -31,15 +30,4 @@ public class PageImpl<T> implements Page<T> {
      * Total pages
      */
     private int totalPages;
-
-    /**
-     * Apply range to a specific Page
-     * @param range range to apply
-     */
-    public void withRange(Range range) {
-        totalElements = range.getTotalElements();
-        if (totalElements > 0) {
-            totalPages = (int) (totalElements / (range.getLimit() - range.getOffset()));
-        }
-    }
 }

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/Pageable.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/Pageable.java
@@ -99,6 +99,7 @@ public interface Pageable {
 
     /**
      * Return the next page
+     *
      * @return next page
      */
     default Pageable next() {
@@ -107,9 +108,19 @@ public interface Pageable {
 
     /**
      * Return the previous page or the first one
+     *
      * @return previous page
      */
     default Pageable previous() {
         return getPageNumber() == 0 ? this : new PageRequest(getPageNumber() - 1, getPageSize(), getSort());
+    }
+
+    /**
+     * Indicates that the pageable object is unPaged
+     *
+     * @return true if unPaged
+     */
+    default boolean hasSize() {
+        return getPageSize() > 0;
     }
 }

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/Range.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/Range.java
@@ -1,6 +1,8 @@
 package fr.ouestfrance.querydsl.postgrest.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -9,6 +11,8 @@ import java.util.regex.Pattern;
  * Range object
  */
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Range {
 
     /**

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/RangeResponse.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/RangeResponse.java
@@ -1,0 +1,46 @@
+package fr.ouestfrance.querydsl.postgrest.model;
+
+import java.util.List;
+
+/**
+ * Postgrest range response
+ *
+ * @param <T>   type of the page
+ * @param data  Elements returned
+ * @param range Range returned (first returned, last returned, total elements)
+ */
+public record RangeResponse<T>(List<T> data, Range range) {
+
+    /**
+     * Create a range response from a list of elements
+     *
+     * @param items elements
+     * @param <T>   type of the elements
+     * @return range response
+     */
+    @SafeVarargs
+    public static <T> RangeResponse<T> of(T... items) {
+        return new RangeResponse<>(List.of(items), null);
+    }
+
+    /**
+     * Retrieve total elements from range response
+     *
+     * @return total elements
+     */
+    public long getTotalElements() {
+        return (range != null) ? range.getTotalElements() : data.size();
+    }
+
+    /**
+     * Retrieve page size from range response
+     *
+     * @return page size
+     */
+    public int getPageSize() {
+        if (range != null) {
+            return range.getLimit() - range.getOffset() + 1;
+        }
+        return data.isEmpty() ? 1 : data.size();
+    }
+}

--- a/querydsl-postgrest/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestRepositoryGetMockTest.java
+++ b/querydsl-postgrest/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestRepositoryGetMockTest.java
@@ -2,10 +2,7 @@ package fr.ouestfrance.querydsl.postgrest;
 
 import fr.ouestfrance.querydsl.postgrest.app.*;
 import fr.ouestfrance.querydsl.postgrest.criterias.Criteria;
-import fr.ouestfrance.querydsl.postgrest.model.Page;
-import fr.ouestfrance.querydsl.postgrest.model.PageImpl;
-import fr.ouestfrance.querydsl.postgrest.model.Pageable;
-import fr.ouestfrance.querydsl.postgrest.model.Sort;
+import fr.ouestfrance.querydsl.postgrest.model.*;
 import fr.ouestfrance.querydsl.postgrest.model.exceptions.PostgrestRequestException;
 import fr.ouestfrance.querydsl.postgrest.utils.QueryStringUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +37,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
 
     @Test
     void shouldSearchAllPosts() {
-        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(Page.of(new Post(), new Post()));
+        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post(), new Post()));
         Page<Post> search = repository.search(null);
         assertNotNull(search);
         assertNotNull(search.iterator());
@@ -60,7 +57,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
         request.setValidDate(LocalDate.of(2023, 11, 10));
         ArgumentCaptor<Map<String, List<String>>> queryArgs = multiMapCaptor();
         ArgumentCaptor<Map<String, List<String>>> headerArgs = multiMapCaptor();
-        when(webClient.search(anyString(), queryArgs.capture(), headerArgs.capture(), eq(Post.class))).thenReturn(Page.of(new Post(), new Post()));
+        when(webClient.search(anyString(), queryArgs.capture(), headerArgs.capture(), eq(Post.class))).thenReturn(RangeResponse.of(new Post(), new Post()));
 
         Page<Post> search = repository.search(request, Pageable.ofSize(10, Sort.by(Sort.Order.asc("id"), Sort.Order.desc("title").nullsFirst(), Sort.Order.asc("author").nullsLast())));
         assertNotNull(search);
@@ -94,7 +91,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
     @Test
     void shouldFindById() {
         ArgumentCaptor<Map<String, List<String>>> queryArgs = multiMapCaptor();
-        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(Page.of(new Post()));
+        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post()));
         Page<Post> search = repository.search(Criteria.byId("1"), Pageable.ofSize(6));
         // Assert query captors
         Map<String, List<String>> queries = queryArgs.getValue();
@@ -108,7 +105,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
     @Test
     void shouldFindByIds() {
         ArgumentCaptor<Map<String, List<String>>> queryArgs = multiMapCaptor();
-        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(Page.of(new Post()));
+        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post()));
         Page<Post> search = repository.search(Criteria.byIds("1", "2", "3"), Pageable.ofSize(6));
         // Assert query captors
         Map<String, List<String>> queries = queryArgs.getValue();
@@ -128,7 +125,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
         request.setCodes(List.of("a", "b", "c"));
         request.setExcludes(List.of("z"));
         request.setValidDate(LocalDate.of(2023, 11, 10));
-        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(new PageImpl<>(List.of(new Post()), null, 2, 2));
+        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(new RangeResponse<>(List.of(new Post()),new Range(0,1,2)));
 
         Page<Post> search = repository.search(request, Pageable.ofSize(1, Sort.by(Sort.Order.asc("id"))));
         assertNotNull(search);
@@ -159,7 +156,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
         request.setValidDate(LocalDate.of(2023, 11, 10));
         ArgumentCaptor<Map<String, List<String>>> queryArgs = multiMapCaptor();
         ArgumentCaptor<Map<String, List<String>>> headerArgs = multiMapCaptor();
-        when(webClient.search(anyString(), queryArgs.capture(), headerArgs.capture(), eq(Post.class))).thenReturn(new PageImpl<>(List.of(new Post()), null, 2, 2));
+        when(webClient.search(anyString(), queryArgs.capture(), headerArgs.capture(), eq(Post.class))).thenReturn(new RangeResponse<>(List.of(new Post()),  new Range(0,2, 2)));
 
         Page<Post> search = repository.search(request, Pageable.ofSize(1, 1, Sort.by(Sort.Order.asc("id"))));
         assertNotNull(search);
@@ -182,7 +179,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
         PostRequest request = new PostRequest();
         ArgumentCaptor<Map<String, List<String>>> queryArgs = multiMapCaptor();
         ArgumentCaptor<Map<String, List<String>>> headerArgs = multiMapCaptor();
-        when(webClient.search(anyString(), queryArgs.capture(), headerArgs.capture(), eq(Post.class))).thenReturn(Page.of(new Post(), new Post()));
+        when(webClient.search(anyString(), queryArgs.capture(), headerArgs.capture(), eq(Post.class))).thenReturn(RangeResponse.of(new Post(), new Post()));
 
         Page<Post> search = repository.search(request, Pageable.ofSize(10));
         assertNotNull(search);
@@ -199,13 +196,13 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
 
     @Test
     void shouldRaiseExceptionOnMultipleOne() {
-        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(Page.of(new Post(), new Post()));
+        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post(), new Post()));
         assertThrows(PostgrestRequestException.class, () -> repository.findOne(null));
     }
 
     @Test
     void shouldFindOne() {
-        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(Page.of(new Post()));
+        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post()));
         Optional<Post> one = repository.findOne(null);
         assertNotNull(one);
         assertTrue(one.isPresent());
@@ -214,7 +211,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
 
     @Test
     void shouldFindEmptyOne() {
-        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(Page.of());
+        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(RangeResponse.of());
         Optional<Post> one = repository.findOne(null);
         assertNotNull(one);
         assertTrue(one.isEmpty());
@@ -223,14 +220,14 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
 
     @Test
     void shouldGetOne() {
-        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(Page.of(new Post()));
+        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post()));
         Post one = repository.getOne(null);
         assertNotNull(one);
     }
 
     @Test
     void shouldRaiseExceptionOnEmptyGetOne() {
-        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(Page.of());
+        when(webClient.search(anyString(), any(), any(), eq(Post.class))).thenReturn(RangeResponse.of());
         assertThrows(PostgrestRequestException.class, () -> repository.getOne(null));
     }
 
@@ -239,7 +236,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
         PostRequestWithSize request = new PostRequestWithSize();
         request.setSize("25");
         ArgumentCaptor<Map<String, List<String>>> queryArgs = multiMapCaptor();
-        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(Page.of(new Post(), new Post()));
+        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post(), new Post()));
         Page<Post> search = repository.search(request, Pageable.unPaged());
         assertNotNull(search);
         assertEquals(2, search.size());
@@ -259,7 +256,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
         request.setAuthor("IA");
         request.setSubject("IA");
         ArgumentCaptor<Map<String, List<String>>> queryArgs = multiMapCaptor();
-        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(Page.of(new Post(), new Post()));
+        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post(), new Post()));
 
         Page<Post> search = repository.search(request, Pageable.ofSize(10));
         assertNotNull(search);
@@ -282,7 +279,7 @@ class PostgrestRepositoryGetMockTest extends AbstractRepositoryMockTest {
         request.setPortee("['DEPARTEMENT']");
         request.setDateValide(LocalDate.of(2023, 12, 4));
         ArgumentCaptor<Map<String, List<String>>> queryArgs = multiMapCaptor();
-        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(Page.of(new Post(), new Post()));
+        when(webClient.search(anyString(), queryArgs.capture(), any(), eq(Post.class))).thenReturn(RangeResponse.of(new Post(), new Post()));
 
         Page<Post> search = repository.search(request, Pageable.ofSize(10));
         assertNotNull(search);

--- a/querydsl-postgrest/src/test/java/fr/ouestfrance/querydsl/postgrest/model/PageTest.java
+++ b/querydsl-postgrest/src/test/java/fr/ouestfrance/querydsl/postgrest/model/PageTest.java
@@ -18,17 +18,7 @@ class PageTest {
         assertNotNull(map);
         assertTrue(map.stream().anyMatch(Objects::nonNull));
     }
-
-    @Test
-    void withRange() {
-        List<Integer> items = List.of(1, 2, 3);
-        PageImpl<Integer> page = new PageImpl<>(items, null, items.size(), 1);
-        page.withRange(Range.of("0-3/3"));
-        assertNotNull(page);
-        assertEquals(3, page.getTotalElements());
-        assertEquals(1, page.getTotalPages());
-    }
-
+    
     @Test
     void shouldEmptyPage() {
         Page<Integer> page = Page.empty();


### PR DESCRIPTION
Page result failure on totalPages calculation

PostgrestClient only know resultData and RangeInformation (Offset-Limit/Count) -> Example : (0-9/995) 
Before : 
Calculate total pages on 995 / ((9-0)+1) => 100 pages (99 pages of 10 elements + 1 page of 5 element)
But fail on last page because range result is 990-995/995 => will calculate totalPages on 995 / 5 items

Now : 
Calculation is based on PageRequest items and not only on the result