### PR TITLE
feat: allow rpc calls

### DIFF
--- a/querydsl-postgrest-resttemplate-adapter/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestRestTemplate.java
+++ b/querydsl-postgrest-resttemplate-adapter/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestRestTemplate.java
@@ -6,6 +6,7 @@ import fr.ouestfrance.querydsl.postgrest.model.HeaderRange;
 import fr.ouestfrance.querydsl.postgrest.model.RangeResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -15,6 +16,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +68,7 @@ public class PostgrestRestTemplate implements PostgrestClient {
     }
 
     @Override
-    public <T> BulkResponse<T> post(String resource, Map<String, List<String>> params, List<Object> value, Map<String, List<String>> headers, Class<T> clazz) {
+    public <T> BulkResponse<T> post(String resource, Map<String, List<String>> params, Object value, Map<String, List<String>> headers, Class<T> clazz) {
         ResponseEntity<List<T>> response = restTemplate.exchange(
                 getUri(resource, params),
                 HttpMethod.POST, new HttpEntity<>(value, toHeaders(headers)), listRef(clazz));
@@ -93,6 +95,12 @@ public class PostgrestRestTemplate implements PostgrestClient {
     public List<CountItem> count(String resource, Map<String, List<String>> map) {
         return restTemplate.exchange(
                 getUri(resource, map), HttpMethod.GET, new HttpEntity<>(null, new HttpHeaders()), listRef(CountItem.class)).getBody();
+    }
+
+    @Override
+    public <V> V rpc(String rpcName, Map<String, List<String>> map, Object body, Type type) {
+        return (V) restTemplate.exchange(
+                getUri(rpcName, map), HttpMethod.POST, new HttpEntity<>(body, new HttpHeaders()), ParameterizedTypeReference.forType(type)).getBody();
     }
 
 

--- a/querydsl-postgrest-resttemplate-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestRpcTest.java
+++ b/querydsl-postgrest-resttemplate-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestRpcTest.java
@@ -1,0 +1,75 @@
+package fr.ouestfrance.querydsl.postgrest;
+
+import fr.ouestfrance.querydsl.postgrest.app.Post;
+import fr.ouestfrance.querydsl.postgrest.app.PostRequestWithSelect;
+import org.apache.commons.lang3.reflect.TypeUtils;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.jupiter.MockServerSettings;
+import org.mockserver.model.HttpRequest;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static fr.ouestfrance.querydsl.postgrest.TestUtils.jsonResponse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MockServerSettings(ports = 8007)
+class PostgrestRpcTest {
+
+    private PostgrestRpcClient rpcClient;
+
+    @BeforeEach
+    void beforeEach(MockServerClient client) {
+        client.reset();
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory(HttpClients.createDefault()));
+        PostgrestRestTemplate postgrestRestTemplate = PostgrestRestTemplate.of(restTemplate, "http://localhost:8007");
+        rpcClient = new PostgrestRpcClient(postgrestRestTemplate);
+    }
+
+    @Test
+    void shouldCallRpc(MockServerClient client) {
+        client.when(HttpRequest.request().withPath("/rpc/testV1"))
+                .respond(jsonResponse("""
+                        {"id": 1, "title": "test"}
+                        """));
+        Post result = rpcClient.executeRpc("testV1",  Post.class);
+        assertNotNull(result);
+    }
+
+    @Test
+    void shouldCallRpcWithCriteria(MockServerClient client) {
+        client.when(HttpRequest.request().withPath("/rpc/testV1")
+                        .withQueryStringParameter("userId", "eq.1")
+                        .withQueryStringParameter("select", "title,userId"))
+                .respond(jsonResponse("""
+                        {"id": 1, "title": "test"}
+                        """));
+
+        PostRequestWithSelect criteria = new PostRequestWithSelect();
+        criteria.setUserId(1);
+        Post result = rpcClient.executeRpc("testV1", criteria,null, Post.class);
+        assertNotNull(result);
+        System.out.println(result);
+    }
+
+    @Test
+    void shouldCallRpcWithCriteriaResultIsList(MockServerClient client) {
+        client.when(HttpRequest.request().withPath("/rpc/testV1")
+                        .withQueryStringParameter("userId", "eq.1")
+                        .withQueryStringParameter("select", "title,userId"))
+                .respond(jsonResponse("""
+                        [{"id": 1, "title": "test"}]
+                        """));
+
+        PostRequestWithSelect criteria = new PostRequestWithSelect();
+        criteria.setUserId(1);
+        List<Post> result = rpcClient.executeRpc("testV1", criteria, null, TypeUtils.parameterize(List.class, Post.class));
+        assertNotNull(result);
+        System.out.println(result);
+    }
+}

--- a/querydsl-postgrest-resttemplate-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/TestUtils.java
+++ b/querydsl-postgrest-resttemplate-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/TestUtils.java
@@ -1,0 +1,29 @@
+package fr.ouestfrance.querydsl.postgrest;
+
+import lombok.SneakyThrows;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.MediaType;
+import shaded_package.org.apache.commons.io.IOUtils;
+
+import java.nio.charset.Charset;
+
+import static org.mockserver.model.HttpResponse.response;
+
+public class TestUtils {
+
+    public static HttpResponse jsonResponse(String content) {
+        return HttpResponse.response().withContentType(MediaType.APPLICATION_JSON)
+                .withBody(content);
+    }
+
+
+    public static HttpResponse jsonFileResponse(String resourceFileName) {
+        return response().withContentType(MediaType.APPLICATION_JSON)
+                .withBody(jsonOf(resourceFileName));
+    }
+
+    @SneakyThrows
+    public static String jsonOf(String name) {
+        return IOUtils.resourceToString(name, Charset.defaultCharset(), TestUtils.class.getClassLoader());
+    }
+}

--- a/querydsl-postgrest-resttemplate-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostRequestWithSelect.java
+++ b/querydsl-postgrest-resttemplate-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostRequestWithSelect.java
@@ -1,0 +1,22 @@
+package fr.ouestfrance.querydsl.postgrest.app;
+
+import fr.ouestfrance.querydsl.FilterField;
+import fr.ouestfrance.querydsl.FilterOperation;
+import fr.ouestfrance.querydsl.postgrest.annotations.Select;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Select({"title", "userId"})
+public class PostRequestWithSelect {
+
+    @FilterField
+    private Integer userId;
+    @FilterField(operation = FilterOperation.NEQ.class)
+    private Integer id;
+}

--- a/querydsl-postgrest-webclient-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestWebClientRepositoryTest.java
+++ b/querydsl-postgrest-webclient-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestWebClientRepositoryTest.java
@@ -8,9 +8,12 @@ import fr.ouestfrance.querydsl.postgrest.model.Pageable;
 import fr.ouestfrance.querydsl.postgrest.model.Range;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.TypeUtils;
 import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.junit.jupiter.MockServerSettings;
+import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -21,6 +24,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import static fr.ouestfrance.querydsl.postgrest.TestUtils.jsonFileResponse;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -29,9 +33,10 @@ import static org.mockserver.model.HttpResponse.response;
 @Slf4j
 class PostgrestWebClientRepositoryTest {
 
-    private final PostgrestRepository<Post> repository = new PostRepository(PostgrestWebClient.of(WebClient.builder()
+    private final PostgrestWebClient client = PostgrestWebClient.of(WebClient.builder()
             .baseUrl("http://localhost:8007/")
-            .build()));
+            .build());
+    private final PostgrestRepository<Post> repository = new PostRepository(client);
 
 
     @Test
@@ -178,15 +183,8 @@ class PostgrestWebClientRepositoryTest {
         assertTrue(result.isEmpty());
     }
 
-    private HttpResponse jsonFileResponse(String resourceFileName) {
-        return response().withContentType(MediaType.APPLICATION_JSON)
-                .withBody(jsonOf(resourceFileName));
-    }
 
-    @SneakyThrows
-    private String jsonOf(String name) {
-        return IOUtils.resourceToString(name, Charset.defaultCharset(), getClass().getClassLoader());
-    }
+
 
 
     @Test
@@ -213,6 +211,4 @@ class PostgrestWebClientRepositoryTest {
         Page<Post> oldWaySearch = repository.search(oldWayRangeRequest, Pageable.ofSize(6));
         assertNotNull(oldWaySearch);
     }
-
-
 }

--- a/querydsl-postgrest-webclient-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestWebClientRpcTest.java
+++ b/querydsl-postgrest-webclient-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestWebClientRpcTest.java
@@ -1,0 +1,73 @@
+package fr.ouestfrance.querydsl.postgrest;
+
+import fr.ouestfrance.querydsl.postgrest.app.Post;
+import fr.ouestfrance.querydsl.postgrest.app.PostRequestWithSelect;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.TypeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.jupiter.MockServerSettings;
+import org.mockserver.model.HttpRequest;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+import static fr.ouestfrance.querydsl.postgrest.TestUtils.jsonResponse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MockServerSettings(ports = 8007)
+@Slf4j
+class PostgrestWebClientRpcTest {
+
+    private final PostgrestWebClient client = PostgrestWebClient.of(WebClient.builder()
+            .baseUrl("http://localhost:8007/")
+            .build());
+    private final PostgrestRpcClient rpcClient = new PostgrestRpcClient(client);
+
+    @BeforeEach
+    void beforeEach(MockServerClient client) {
+        client.reset();
+    }
+
+    @Test
+    void shouldCallRpc(MockServerClient client) {
+        client.when(HttpRequest.request().withPath("/rpc/testV1"))
+                .respond(jsonResponse("""
+                        {"id": 1, "title": "test"}
+                        """));
+        Post result = rpcClient.executeRpc("testV1", Post.class);
+        assertNotNull(result);
+    }
+
+    @Test
+    void shouldCallRpcWithCriteria(MockServerClient client) {
+        client.when(HttpRequest.request().withPath("/rpc/testV1")
+                        .withQueryStringParameter("userId", "eq.1")
+                        .withQueryStringParameter("select", "title,userId"))
+                .respond(jsonResponse("""
+                        {"id": 1, "title": "test"}
+                        """));
+
+        PostRequestWithSelect criteria = new PostRequestWithSelect();
+        criteria.setUserId(1);
+        Post result = rpcClient.executeRpc("testV1", criteria, null, Post.class);
+        assertNotNull(result);
+    }
+
+    @Test
+    void shouldCallRpcWithCriteriaResultIsList(MockServerClient client) {
+        client.when(HttpRequest.request().withPath("/rpc/testV1")
+                        .withQueryStringParameter("userId", "eq.1")
+                        .withQueryStringParameter("select", "title,userId"))
+                .respond(jsonResponse("""
+                        [{"id": 1, "title": "test"}]
+                        """));
+
+        PostRequestWithSelect criteria = new PostRequestWithSelect();
+        criteria.setUserId(1);
+        List<Post> result = rpcClient.executeRpc("testV1", criteria, null, TypeUtils.parameterize(List.class, Post.class));
+        assertNotNull(result);
+    }
+
+}

--- a/querydsl-postgrest-webclient-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/TestUtils.java
+++ b/querydsl-postgrest-webclient-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/TestUtils.java
@@ -1,0 +1,29 @@
+package fr.ouestfrance.querydsl.postgrest;
+
+import lombok.SneakyThrows;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.MediaType;
+import shaded_package.org.apache.commons.io.IOUtils;
+
+import java.nio.charset.Charset;
+
+import static org.mockserver.model.HttpResponse.response;
+
+public class TestUtils {
+
+    public static HttpResponse jsonResponse(String content) {
+        return HttpResponse.response().withContentType(MediaType.APPLICATION_JSON)
+                .withBody(content);
+    }
+
+
+    public static HttpResponse jsonFileResponse(String resourceFileName) {
+        return response().withContentType(MediaType.APPLICATION_JSON)
+                .withBody(jsonOf(resourceFileName));
+    }
+
+    @SneakyThrows
+    public static String jsonOf(String name) {
+        return IOUtils.resourceToString(name, Charset.defaultCharset(), TestUtils.class.getClassLoader());
+    }
+}

--- a/querydsl-postgrest-webclient-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostRequestWithSelect.java
+++ b/querydsl-postgrest-webclient-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/app/PostRequestWithSelect.java
@@ -1,0 +1,25 @@
+package fr.ouestfrance.querydsl.postgrest.app;
+
+import fr.ouestfrance.querydsl.FilterField;
+import fr.ouestfrance.querydsl.FilterOperation;
+import fr.ouestfrance.querydsl.postgrest.annotations.Select;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Select({"title", "userId"})
+public class PostRequestWithSelect {
+
+    @FilterField
+    private Integer userId;
+    @FilterField(operation = FilterOperation.NEQ.class)
+    private Integer id;
+}

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestClient.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestClient.java
@@ -4,6 +4,7 @@ import fr.ouestfrance.querydsl.postgrest.model.BulkResponse;
 import fr.ouestfrance.querydsl.postgrest.model.CountItem;
 import fr.ouestfrance.querydsl.postgrest.model.RangeResponse;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ public interface PostgrestClient {
      * @param clazz    type of return
      * @return list of inserted objects
      */
-    <T> BulkResponse<T> post(String resource, Map<String, List<String>> queryParams, List<Object> value, Map<String, List<String>> headers, Class<T> clazz);
+    <T> BulkResponse<T> post(String resource, Map<String, List<String>> queryParams, Object value, Map<String, List<String>> headers, Class<T> clazz);
 
     /**
      * Patch data
@@ -70,4 +71,16 @@ public interface PostgrestClient {
      * @return list of count items
      */
     List<CountItem> count(String resource, Map<String, List<String>> map);
+
+    /**
+     * Call RPC
+     *
+     * @param rpcName rpc name
+     * @param params  query params
+     * @param body    body request to send
+     * @param type    class of return
+     * @param <V>     type of return object
+     * @return MultiValueMap
+     */
+    <V> V rpc(String rpcName, Map<String, List<String>> params, Object body, Type type);
 }

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestRpcClient.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/PostgrestRpcClient.java
@@ -1,0 +1,79 @@
+package fr.ouestfrance.querydsl.postgrest;
+
+import fr.ouestfrance.querydsl.postgrest.model.Filter;
+import fr.ouestfrance.querydsl.postgrest.model.impl.SelectFilter;
+import fr.ouestfrance.querydsl.postgrest.services.ext.PostgrestQueryProcessorService;
+import fr.ouestfrance.querydsl.postgrest.utils.FilterUtils;
+import fr.ouestfrance.querydsl.service.ext.QueryDslProcessorService;
+import lombok.RequiredArgsConstructor;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class PostgrestRpcClient {
+
+    private static final String RPC = "rpc/";
+    private final PostgrestClient client;
+    private final QueryDslProcessorService<Filter> processorService = new PostgrestQueryProcessorService();
+
+    /**
+     * Execute a rpc call without body
+     *
+     * @param rpcName rpc name
+     * @param type    class of return
+     * @param <V>     type of the return object
+     * @return response
+     */
+    public <V> V executeRpc(String rpcName, Type type) {
+        return executeRpc(rpcName, null, type);
+    }
+
+    /**
+     * Execute a rpc call
+     *
+     * @param rpcName rpc name
+     * @param body    body request to send
+     * @param type    class of return
+     * @param <V>     type of return object
+     * @return response
+     */
+    public <V> V executeRpc(String rpcName, Object body, Type type) {
+        return executeRpc(rpcName, null, body, type);
+    }
+
+
+    /**
+     * Execute a rpc call
+     *
+     * @param rpcName rpc name
+     * @param body    body request to send
+     * @param type    class of return
+     * @param <V>     type of return object
+     * @return response
+     */
+    public <V> V executeRpc(String rpcName, Object criteria, Object body, Type type) {
+        // List filters
+        List<Filter> queryParams = processorService.process(criteria);
+        // Extract selection
+        getSelects(criteria).ifPresent(queryParams::add);
+
+        return client.rpc(RPC + rpcName, FilterUtils.toMap(queryParams), body, type);
+    }
+
+
+    /**
+     * Extract selection on criteria and class
+     *
+     * @param criteria search criteria
+     * @return attributes
+     */
+    private Optional<Filter> getSelects(Object criteria) {
+        return Optional.of(FilterUtils.getSelectAttributes(criteria))
+                .filter(x -> !x.isEmpty())
+                .map(SelectFilter::only);
+    }
+
+}

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/Repository.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/Repository.java
@@ -6,6 +6,8 @@ import fr.ouestfrance.querydsl.postgrest.model.Page;
 import fr.ouestfrance.querydsl.postgrest.model.Pageable;
 import fr.ouestfrance.querydsl.postgrest.model.exceptions.PostgrestRequestException;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Optional;
 
@@ -177,5 +179,6 @@ public interface Repository<T> {
      * @return list of deleted items
      */
     BulkResponse<T> delete(Object criteria, BulkOptions options);
+
 
 }

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/annotations/Select.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/annotations/Select.java
@@ -16,7 +16,7 @@ public @interface Select {
      * Selection
      * @return string representation of the selection
      */
-    String value();
+    String[] value();
 
     /**
      * Select the value as a specific alias name

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/impl/SelectFilter.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/impl/SelectFilter.java
@@ -4,6 +4,7 @@ import fr.ouestfrance.querydsl.postgrest.builders.FilterVisitor;
 import fr.ouestfrance.querydsl.postgrest.builders.QueryFilterVisitor;
 import fr.ouestfrance.querydsl.postgrest.model.Filter;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +14,7 @@ import java.util.List;
  * Select filter allow to describe a selection
  */
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SelectFilter implements Filter, FilterVisitor {
 
     /**
@@ -23,7 +24,8 @@ public class SelectFilter implements Filter, FilterVisitor {
     /**
      * alias
      */
-    private final List<Attribute> selectAttributes;
+    private List<Attribute> selectAttributes;
+    private boolean addAll;
 
     /**
      * Create select filter from embedded resources
@@ -32,7 +34,19 @@ public class SelectFilter implements Filter, FilterVisitor {
      * @return select filter
      */
     public static Filter of(List<Attribute> selectAttributes) {
-        return new SelectFilter(selectAttributes);
+        return new SelectFilter(selectAttributes, true);
+    }
+
+    public static Filter only(List<Attribute> selectAttributes) {
+        return new SelectFilter(selectAttributes, false);
+    }
+
+    public Filter append(List<Attribute> selectAttributes) {
+        if(selectAttributes == null || selectAttributes.isEmpty()) {
+            return this;
+        }
+        this.selectAttributes.addAll(selectAttributes);
+        return this;
     }
 
     @Override
@@ -59,7 +73,7 @@ public class SelectFilter implements Filter, FilterVisitor {
         /**
          * value selected
          */
-        private final String value;
+        private final String[] value;
 
     }
 }

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/utils/FilterUtils.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/utils/FilterUtils.java
@@ -1,0 +1,58 @@
+package fr.ouestfrance.querydsl.postgrest.utils;
+
+import fr.ouestfrance.querydsl.postgrest.annotations.Select;
+import fr.ouestfrance.querydsl.postgrest.model.Filter;
+import fr.ouestfrance.querydsl.postgrest.model.impl.CompositeFilter;
+import fr.ouestfrance.querydsl.postgrest.model.impl.SelectFilter;
+import fr.ouestfrance.querydsl.postgrest.model.impl.SelectFilter.Attribute;
+
+import java.util.*;
+
+public class FilterUtils {
+
+
+    private static final String AND = "and";
+
+    /**
+     * Get attributes from objects
+     * @param objects objects to scan
+     * @return list of select attributes
+     */
+    public static List<Attribute> getSelectAttributes(Object... objects) {
+        List<SelectFilter.Attribute> attributes = new ArrayList<>();
+        if(objects == null) {
+            return attributes;
+        }
+        for (Object object : objects) {
+            if(object != null) {
+                Select[] clazzAnnotation = object.getClass().getAnnotationsByType(Select.class);
+                if (clazzAnnotation.length > 0) {
+                    attributes.addAll(Arrays.stream(clazzAnnotation).map(x -> new SelectFilter.Attribute(x.alias(), x.value())).toList());
+                }
+            }
+        }
+        return attributes;
+    }
+
+    /**
+     * Transform a filter list to map of queryString
+     *
+     * @param filters list of filters
+     * @return map of query strings
+     */
+    public static Map<String, List<String>> toMap(List<Filter> filters) {
+        Map<String, List<String>> map = new LinkedHashMap<>();
+        filters.forEach(x -> {
+            // If filter is an "and" with the same keys, then we decompose it and transform it to filter list
+            if (x instanceof CompositeFilter compositeFilter && AND.equals(compositeFilter.getKey()) &&
+                compositeFilter.getFilters().stream().map(Filter::getKey).distinct().count() == 1) {
+                for (Filter filter : compositeFilter.getFilters()) {
+                    map.computeIfAbsent(filter.getKey(), key -> new ArrayList<>()).add(filter.getFilterString());
+                }
+            } else {
+                map.computeIfAbsent(x.getKey(), key -> new ArrayList<>()).add(x.getFilterString());
+            }
+        });
+        return map;
+    }
+}


### PR DESCRIPTION
Supports of [rpc function calls](https://postgrest.org/en/v12/references/api/functions.html#functions-as-rpc)

**Configuration**
Its use a PostgrestRpcClient which use the PostgrestClient

```java
import com.fasterxml.jackson.databind.ObjectMapper;
import fr.ouestfrance.querydsl.postgrest.PostgrestClient;
import fr.ouestfrance.querydsl.postgrest.PostgrestWebClient;
import fr.ouestfrance.querydsl.postgrest.PostgrestRpcClient;
import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Configuration;
import org.springframework.web.reactive.function.client.WebClient;

@Configuration
public class PostgrestConfiguration {

    @Bean
    public PostgrestRpcClient rpcClient() {
        String serviceUrl = "http://localhost:9000";
        WebClient webclient = WebClient.builder()
                .baseUrl(serviceUrl)
                // Here you can add any filters or default configuration you want
                .build();

        return new PostgrestRpcClient(PostgrestWebClient.of(webclient));
    }
}
```

then you can call your rpc method using this call 

```java
public class Example{
    private PostgrestRpcClient rpcClient;
    
    public List<Coordinate> getCoordinates(){
        // call getCoordinates_v1 and expect to return a list of Coordinates
        return rpcClient.exectureRpc("getCoordinates_v1", TypeUtils.parameterize(List.class, Coordinate.class));
        // CALL => ${base_url}/rpc/getCoordinates_v1
    }
    
    public Coordinate getCoordinate(Point point){
        // call findClosestCoordinate_v1 with body {x:?, y:?} 
        // expect to return a single coordinate
        return rpcClient.executeRpc("findClosestCoordinate_v1", point, Coordinate.class);
        // CALL => ${base_url}/rpc/findClosestCoordinate_v1
        // => with body {x: point.x, y: point.y}
    }
    
    public SimpleCoordinate getCoordinateX(Point point){
        // call findClosestCoordinate_v1 with body {x:?, y:?}
        // add Criteria that add select=x,y and z=gte.0.0
        // and return the result as a SimpleCoordinate class
        return rpcClient.executeRpc("findClosestCoordinate_v1", new CoordinateCriteria(0.0), point, SimpleCoordinate.class);
        // CALL => ${base_url}/rpc/findClosestCoordinate_v1?z=gte.0.0&select=x,y
        // => with body {x: point.x, y: point.y}
    }
    
    
    @Select({"x", "y"})
    record CoordinateCriteria(
            @FilterField(key = "z", operation = FilterOperation.GTE.class)
            private Float z
    ){}
    
    record SimpleCoordinate(Float x, Float y){}
}
```