### PR TITLE
feat: rethrow notfound exception as badRequest on rpc calls

### DIFF
--- a/querydsl-postgrest-resttemplate-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestRpcTest.java
+++ b/querydsl-postgrest-resttemplate-adapter/src/test/java/fr/ouestfrance/querydsl/postgrest/PostgrestRpcTest.java
@@ -2,6 +2,7 @@ package fr.ouestfrance.querydsl.postgrest;
 
 import fr.ouestfrance.querydsl.postgrest.app.Post;
 import fr.ouestfrance.querydsl.postgrest.app.PostRequestWithSelect;
+import fr.ouestfrance.querydsl.postgrest.model.exceptions.PostgrestRequestException;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,7 @@ import java.util.List;
 
 import static fr.ouestfrance.querydsl.postgrest.TestUtils.jsonResponse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @MockServerSettings(ports = 8007)
 class PostgrestRpcTest {
@@ -71,5 +73,22 @@ class PostgrestRpcTest {
         List<Post> result = rpcClient.executeRpc("testV1", criteria, null, TypeUtils.parameterize(List.class, Post.class));
         assertNotNull(result);
         System.out.println(result);
+    }
+
+
+    @Test
+    void shouldRaiseExceptionOn404(MockServerClient client) {
+        client.when(HttpRequest.request().withPath("/rpc/testV1"))
+                .respond(jsonResponse("""
+                        {
+                            "code":"PGRST202",
+                            "details":"Searched for the function public_repository_depositaire.testV1 with parameters coordinates, type or with a single unnamed json/jsonb parameter, but no matches were found in the schema cache.",
+                            "hint":null,
+                            "message":"Could not find the function public_repository_depositaire.testV1(coordinates, type) in the schema cache"
+                        }
+                        """).withStatusCode(404));
+        PostgrestRequestException exception = assertThrows(PostgrestRequestException.class, () -> rpcClient.executeRpc("testV1", Post.class));
+        assertNotNull(exception);
+        assertNotNull(exception.getResponseBody());
     }
 }

--- a/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/exceptions/PostgrestRequestException.java
+++ b/querydsl-postgrest/src/main/java/fr/ouestfrance/querydsl/postgrest/model/exceptions/PostgrestRequestException.java
@@ -1,9 +1,16 @@
 package fr.ouestfrance.querydsl.postgrest.model.exceptions;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Runtime exception for querying failure
  */
+@Getter
+@Setter
 public class PostgrestRequestException extends RuntimeException {
+
+    private String responseBody;
 
     /**
      * PostgrestRequestException constructor
@@ -30,6 +37,19 @@ public class PostgrestRequestException extends RuntimeException {
 
     /**
      * PostgrestRequestException constructor
+     * @param resourceName resource name
+     * @param message cause message
+     * @param cause exception raised
+     * @param errorBody error body
+     */
+    public PostgrestRequestException(String resourceName, String message, Throwable cause, String errorBody) {
+        this("Error on querying " + resourceName + " cause by " + message, cause);
+        this.responseBody = errorBody;
+    }
+
+
+    /**
+     * PostgrestRequestException constructor
      *
      * @param message cause message
      */
@@ -46,4 +66,6 @@ public class PostgrestRequestException extends RuntimeException {
     public PostgrestRequestException(String message, Throwable cause) {
         super(message, cause);
     }
+
+
 }


### PR DESCRIPTION
Whn RPC call fail, you got an error like this : 

```json
{"code":"PGRST202","details":"Searched for the function public_repository_depositaire.zoneDcpByCoordonnees_v1 with parameters coordinates, type or with a single unnamed json/jsonb parameter, but no matches were found in the schema cache.","hint":null,"message":"Could not find the function public_repository_depositaire.zoneDcpByCoordonnees_v1(coordinates, type) in the schema cache"}
```
with a 404 status

It allows to raise concrete exception