### PR TITLE
chore: bump querydsl to 1.3.4

### DIFF
--- a/querydsl-postgrest/pom.xml
+++ b/querydsl-postgrest/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>fr.ouestfrance.querydsl</groupId>
             <artifactId>querydsl</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.4</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- Mise à jour de la dépendance `querydsl` : `1.3.1` → `1.3.4`